### PR TITLE
chatspaceのDB設計をreadmeに記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|
+|name|string|index: true, null: false, unique:true|
 |e-mail|string|null: false, unique: true|
 |password|string|null: false|
 |groups_users_id|integer|foreign_key: true|
@@ -10,7 +10,7 @@
 ### Association
 - has_many :groups_users
 - has_many :messages
-- has_many :groups
+- has_many :groups, through: :groups_users
 
 
 ## groupsテーブル
@@ -23,7 +23,7 @@
 ### Association
 - has_many :groups_users
 - has_many :messages
-- has_many :users
+- has_many :users, through: :groups_users
 
 
 ## messagesテーブル

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text|
 |image|string|
 |group_id|integer|foreign_key: true|
 |user_id|integer|foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 |name|string|index: true, null: false, unique:true|
 |e-mail|string|null: false, unique: true|
 |password|string|null: false|
-|groups_users_id|integer|foreign_key: true|
 
 ### Association
 - has_many :groups_users
@@ -17,8 +16,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|group-name|string|
-|groups_users_id|integer|foreign_key: true|
+|name|string|null: false|
 
 ### Association
 - has_many :groups_users
@@ -32,8 +30,8 @@
 |------|----|-------|
 |body|text|
 |image|string|
-|group_id|integer|foreign_key: true|
-|user_id|integer|foreign_key: true|
+|group_id|integer|foreign_key: true, null: false|
+|user_id|integer|foreign_key: true, null: false|
 
 ### Association
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -1,15 +1,52 @@
-##readme
+## usersテーブル
 
-#testtest
-#test_hrnnkou1
+|Column|Type|Options|
+|------|----|-------|
+|name|string|
+|e-mail|string|null: false, unique: true|
+|password|string|null: false|
+|groups_users_id|integer|foreign_key: true|
+
+### Association
+- has_many :groups_users
+- has_many :messages
+- has_many :groups
 
 
-#testtest
-#test_hennkou3
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group-name|string|
+|groups_users_id|integer|foreign_key: true|
+
+### Association
+- has_many :groups_users
+- has_many :messages
+- has_many :users
 
 
-##test100
-##dedolt
+## messagesテーブル
 
-##test400
-##undomae
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string|
+|group_id|integer|foreign_key: true|
+|user_id|integer|foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
#what
chatspaceのDB設計をREADMEに記載した。usersテーブル・groupsテーブル・messagesテーブル・usersテーブルとgroupsテーブルの中間テーブルとしてgroups_usersテーブルを作成
indexはusersテーブルのnameカラムのみ
#why
chatspaceの画面設計から必要カラムを洗い出した。グループ作成画面からusers一覧が表示されていたためusersテーブルのnameカラムにindexを追記した。